### PR TITLE
取最后一个mCurrentFocues，解决存在多个mCurrentFocues判定不到的情况

### DIFF
--- a/modules/utils/adb_utils.py
+++ b/modules/utils/adb_utils.py
@@ -125,7 +125,7 @@ def get_now_running_app(use_config=None):
             if "null" in output:
                 logging.warn({"zh_CN": ">>> MUMU模拟器需要设置里关闭保活！ <<<",
                               "en_US": "If you are using MUMU emulator, please turn off the keep alive in the settings!"})
-            break
+                break
     # 截取app activity
     try:
         app_activity = output.split(" ")[-1].split("}")[0]


### PR DESCRIPTION
resolved #145 
目前看正常情况就一个mCurrentFocues，存在多个的情况也是运行的排在最后一个，故改为取最后一个。
暂时没发现存在多个mCurrentFocues的情况下要取第一个的情况。