### PR TITLE
fix github action export container without git config

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -30,6 +30,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
     build:
       context: .
       # dockerfile: Dockerfile.CN
+    container_name: BAAH
     volumes:
       - ./BAAH_CONFIGS:/app/BAAH_CONFIGS
     environment:

--- a/docs/README_cn.md
+++ b/docs/README_cn.md
@@ -53,6 +53,7 @@ Discord: https://discord.com/invite/7cEvvfcd
 services:
   baah:
     image: ghcr.io/sanmusen214/baah:latest
+    container_name: BAAH
     volumes:
       - ./BAAH_CONFIGS:/app/BAAH_CONFIGS
     environment:

--- a/docs/README_en.md
+++ b/docs/README_en.md
@@ -53,6 +53,7 @@ Discord: https://discord.com/invite/7cEvvfcd
 services:
   baah:
     image: ghcr.io/sanmusen214/baah:latest
+    container_name: BAAH
     volumes:
       - ./BAAH_CONFIGS:/app/BAAH_CONFIGS
     environment:


### PR DESCRIPTION
修改了 `checkout` 的选项现在能导出 `.git` 并且能够使用 `git pull` 了
添加了 `container_name`