### PR TITLE
Build: 直接使用 miniconda 的 base 环境

### DIFF
--- a/.github/workflows/auto_tag_release.yml
+++ b/.github/workflows/auto_tag_release.yml
@@ -28,7 +28,8 @@ jobs:
           miniconda-version: "py310_24.7.1-0"
           python-version: "3.10.14"
           auto-update-conda: false
-          activate-environment: "baah"
+          activate-environment: ""
+          auto-activate: true
 
       - name: Check conda env list
         run: |

--- a/.github/workflows/auto_tag_release.yml
+++ b/.github/workflows/auto_tag_release.yml
@@ -26,7 +26,6 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           miniconda-version: "py310_24.7.1-0"
-          python-version: "3.10.14"
           auto-update-conda: false
           activate-environment: ""
           auto-activate: true

--- a/package.py
+++ b/package.py
@@ -20,6 +20,17 @@ import pponnxcr
 import platform
 import requests
 import tarfile
+import traceback
+
+# 打印 pyinstaller 和 setuptools 版本号
+try:
+    import pyinstaller
+    import setuptools
+    print(f"pyinstaller version: {pyinstaller.__version__}")
+    print(f"setuptools version: {setuptools.__version__}")
+except Exception as e:
+    print(traceback.format_exc())
+
 
 def package_download_adb(platformstr = None):
     

--- a/requirements.txt
+++ b/requirements.txt
@@ -86,6 +86,7 @@ proxy_tools==0.1.0
 pycparser==2.21
 pyinstaller==6.2.0
 pyinstaller-hooks-contrib==2023.10
+setuptools==75.1.0
 pyreadline3==3.4.1
 pythonnet==3.0.3
 pywebview==4.4.1


### PR DESCRIPTION
使用固定 miniconda 版本会得到固定的 base 环境（如 setuptools 版本号），而在这个 miniconda 里创建新虚拟环境 （如 `conda create -n baah python==3.10.14`) 的话 setuptools 版本号会随时间安装新版本，那干脆直接用 action 里的 base 环境得了