### PR TITLE
Fix: GUI not starting on Linux due to freeze_support

### DIFF
--- a/jsoneditor.py
+++ b/jsoneditor.py
@@ -12,8 +12,9 @@ from main import run_baah_script
 def main():
     # Use freeze_support to avoid running GUI again: https://blog.csdn.net/fly_leopard/article/details/121610641
     import multiprocessing
-    multiprocessing.freeze_support()
-    if not multiprocessing.get_start_method(allow_none=True):
+    if sys.platform.startswith('win'):
+        multiprocessing.freeze_support()
+    if multiprocessing.current_process().name == 'MainProcess':
         from gui.refactor_pages import home_page, show_json_panel # 载入路由
         from gui.components.exec_arg_parse import parse_args
         from modules.configs.MyConfig import MyConfigger


### PR DESCRIPTION
修复 Linux 源码部署时 GUI 无法启动


Linux 下执行 `python jsoneditor.py` 立即退出，不启动 GUI。

原因：`freeze_support()` 在 Linux 上会将 start method 从 `None` 改为 `'fork'`，导致条件判断失败，GUI 代码块被跳过。

## 修复

- 仅在 Windows 上调用 `freeze_support()`
- 使用进程名判断替代 start method 判断